### PR TITLE
Allow forcing WebSocket as DialOption to address #35

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
     working_directory: /go/src/github.com/johanbrandhorst/protobuf
     steps:
       - checkout
-      - run: go get -u github.com/golang/dep/cmd/dep
+      - run: curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
       - run: dep ensure -v
       - run: git diff --exit-code
   generate:

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ regenerate:
 
 install:
 	cd protoc-gen-gopherjs && go install ./
+	go install ./vendor/github.com/golang/protobuf/protoc-gen-go
 
 .PHONY: test
 test:

--- a/grpcweb/calloption.go
+++ b/grpcweb/calloption.go
@@ -23,11 +23,12 @@ package grpcweb
 import "google.golang.org/grpc/metadata"
 
 type callInfo struct {
-	headers  metadata.MD
-	trailers metadata.MD
+	headers         metadata.MD
+	trailers        metadata.MD
+	forceWebsockets bool
 }
 
-// CallOption is a stub for any call options that may be implemented
+// CallOption is an interface for any Call Options
 type CallOption interface {
 	before(*callInfo) error
 	after(*callInfo)
@@ -56,5 +57,13 @@ func Header(headers *metadata.MD) CallOption {
 func Trailer(trailers *metadata.MD) CallOption {
 	return afterCall(func(c *callInfo) {
 		*trailers = c.trailers
+	})
+}
+
+// ForceWebsocketTransport forces this call to use the Websocket transport.
+func ForceWebsocketTransport() CallOption {
+	return beforeCall(func(c *callInfo) error {
+		c.forceWebsockets = true
+		return nil
 	})
 }

--- a/grpcweb/client.go
+++ b/grpcweb/client.go
@@ -23,8 +23,9 @@ package grpcweb
 // Client encapsulates all gRPC calls to a
 // host-service combination.
 type Client struct {
-	host    string
-	service string
+	host               string
+	service            string
+	defaultCallOptions []CallOption
 }
 
 // NewClient creates a new Client.

--- a/grpcweb/dialoption.go
+++ b/grpcweb/dialoption.go
@@ -22,3 +22,11 @@ package grpcweb
 
 // DialOption is a stub for any dial options that may be implemented
 type DialOption func(*Client)
+
+// WithDefaultCallOptions sets the options to be used as default
+// CallOptions for all the calls on this client.
+func WithDefaultCallOptions(opts ...CallOption) DialOption {
+	return func(c *Client) {
+		c.defaultCallOptions = append(c.defaultCallOptions, opts...)
+	}
+}

--- a/test/client/main.go
+++ b/test/client/main.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"honnef.co/go/js/dom"
 
+	"github.com/johanbrandhorst/protobuf/grpcweb"
 	"github.com/johanbrandhorst/protobuf/grpcweb/status"
 	grpctest "github.com/johanbrandhorst/protobuf/grpcweb/test"
 	gentest "github.com/johanbrandhorst/protobuf/protoc-gen-gopherjs/test"
@@ -359,6 +360,300 @@ func serverTests(label, serverAddr, emptyServerAddr string) {
 		go func() {
 			defer recoverer.Recover() // recovers any panics and fails tests
 			defer qunit.Start()
+
+			err := shared.TestPingList(w, getStatus)
+			if err != nil {
+				qunit.Ok(false, err.Error())
+				return
+			}
+
+			qunit.Ok(true, "Request succeeded")
+		}()
+
+		return nil
+	})
+
+	qunit.AsyncTest("Unary call to empty server (forcing websocket transport)", func() interface{} {
+		c := test.NewTestServiceClient(uri+emptyServerAddr, grpcweb.WithDefaultCallOptions(grpcweb.ForceWebsocketTransport()))
+
+		go func() {
+			defer recoverer.Recover() // recovers any panics and fails tests
+			defer qunit.Start()
+
+			_, err := c.PingEmpty(context.Background(), &empty.Empty{})
+			if err == nil {
+				qunit.Ok(false, "Expected error, returned nil")
+				return
+			}
+
+			st := status.FromError(err)
+			if st.Message != "unknown service test.TestService" {
+				qunit.Ok(false, "Unexpected error, saw "+st.Message)
+			}
+
+			qunit.Ok(true, "Error was as expected")
+		}()
+
+		return nil
+	})
+
+	qunit.AsyncTest("Unary call to echo server with many types (forcing websocket transport)", func() interface{} {
+		c := types.NewEchoServiceClient(uri+serverAddr, grpcweb.WithDefaultCallOptions(grpcweb.ForceWebsocketTransport()))
+		req := &types.TestAllTypes{
+			SingleInt32:       -math.MaxInt32,
+			SingleInt64:       -math.MaxInt64,
+			SingleUint32:      math.MaxUint32,
+			SingleUint64:      math.MaxUint64,
+			SingleSint32:      -math.MaxInt32,
+			SingleSint64:      -math.MaxInt64,
+			SingleFixed32:     math.MaxUint32,
+			SingleFixed64:     math.MaxUint64,
+			SingleSfixed32:    -math.MaxInt32,
+			SingleSfixed64:    -math.MaxInt64,
+			SingleFloat:       math.MaxFloat32,
+			SingleDouble:      math.MaxFloat64,
+			SingleBool:        true,
+			SingleString:      "Alfred",
+			SingleBytes:       []byte("Megan"),
+			SingleNestedEnum:  types.TestAllTypes_BAR,
+			SingleForeignEnum: types.ForeignEnum_FOREIGN_BAR,
+			SingleImportedMessage: &multi.Multi1{
+				Color:   multi.Multi2_GREEN,
+				HatType: multi.Multi3_FEDORA,
+			},
+			SingleNestedMessage: &types.TestAllTypes_NestedMessage{
+				B: math.MaxInt32,
+			},
+			SingleForeignMessage: &types.ForeignMessage{
+				C: math.MaxInt32,
+			},
+			RepeatedInt32:       []int32{-math.MaxInt32, math.MaxInt32},
+			RepeatedInt64:       []int64{-math.MaxInt64, math.MaxInt64},
+			RepeatedUint32:      []uint32{0, math.MaxUint32},
+			RepeatedUint64:      []uint64{0, math.MaxUint64},
+			RepeatedSint32:      []int32{-math.MaxInt32, math.MaxInt32},
+			RepeatedSint64:      []int64{-math.MaxInt64, math.MaxInt64},
+			RepeatedFixed32:     []uint32{0, math.MaxUint32},
+			RepeatedFixed64:     []uint64{0, math.MaxUint64},
+			RepeatedSfixed32:    []int32{-math.MaxInt32, math.MaxInt32},
+			RepeatedSfixed64:    []int64{-math.MaxInt64, math.MaxInt64},
+			RepeatedFloat:       []float32{-math.MaxFloat32, math.MaxFloat32},
+			RepeatedDouble:      []float64{-math.MaxFloat64, math.MaxFloat64},
+			RepeatedBool:        []bool{true, false, true},
+			RepeatedString:      []string{"Alfred", "Robin", "Simon"},
+			RepeatedBytes:       [][]byte{[]byte("David"), []byte("Henrik")},
+			RepeatedNestedEnum:  []types.TestAllTypes_NestedEnum{types.TestAllTypes_BAR, types.TestAllTypes_BAZ},
+			RepeatedForeignEnum: []types.ForeignEnum{types.ForeignEnum_FOREIGN_BAR, types.ForeignEnum_FOREIGN_BAZ},
+			RepeatedImportedMessage: []*multi.Multi1{
+				{
+					Color:   multi.Multi2_RED,
+					HatType: multi.Multi3_FEZ,
+				},
+				{
+					Color:   multi.Multi2_GREEN,
+					HatType: multi.Multi3_FEDORA,
+				},
+			},
+			RepeatedNestedMessage: []*types.TestAllTypes_NestedMessage{
+				{
+					B: -math.MaxInt32,
+				},
+				{
+					B: math.MaxInt32,
+				},
+			},
+			RepeatedForeignMessage: []*types.ForeignMessage{
+				{
+					C: -math.MaxInt32,
+				},
+				{
+					C: math.MaxInt32,
+				},
+			},
+			OneofField: &types.TestAllTypes_OneofImportedMessage{
+				OneofImportedMessage: &multi.Multi1{
+					Multi2: &multi.Multi2{
+						RequiredValue: math.MaxInt32,
+						Color:         multi.Multi2_BLUE,
+					},
+					Color:   multi.Multi2_RED,
+					HatType: multi.Multi3_FEDORA,
+				},
+			},
+		}
+
+		go func() {
+			defer recoverer.Recover() // recovers any panics and fails tests
+			defer qunit.Start()
+
+			resp, err := c.EchoAllTypes(context.Background(), req)
+			if err != nil {
+				st := status.FromError(err)
+				qunit.Ok(false, "Unexpected error:"+st.Error())
+				return
+			}
+			if diff := deep.Equal(req, resp); diff != nil {
+				var s string
+				for _, v := range diff {
+					s += "\n" + v
+				}
+				qunit.Ok(false, s)
+				return
+			}
+
+			qunit.Ok(true, "Request and Response matched")
+		}()
+
+		return nil
+	})
+
+	qunit.AsyncTest("Unary call to echo server with many maps (forcing websocket transport)", func() interface{} {
+		c := types.NewEchoServiceClient(uri+serverAddr, grpcweb.WithDefaultCallOptions(grpcweb.ForceWebsocketTransport()))
+		req := &types.TestMap{
+			MapInt32Int32: map[int32]int32{
+				1: 2,
+				3: 4,
+			},
+			MapInt64Int64: map[int64]int64{
+				5: 6,
+				7: 8,
+			},
+			MapUint32Uint32: map[uint32]uint32{
+				9:  10,
+				11: 12,
+			},
+			MapUint64Uint64: map[uint64]uint64{
+				13: 14,
+				15: 16,
+			},
+			MapSint32Sint32: map[int32]int32{
+				17: 18,
+				19: 20,
+			},
+			MapSint64Sint64: map[int64]int64{
+				21: 22,
+				23: 24,
+			},
+			MapFixed32Fixed32: map[uint32]uint32{
+				25: 26,
+				27: 28,
+			},
+			MapFixed64Fixed64: map[uint64]uint64{
+				29: 30,
+				31: 32,
+			},
+			MapSfixed32Sfixed32: map[int32]int32{
+				33: 34,
+				35: 36,
+			},
+			MapSfixed64Sfixed64: map[int64]int64{
+				37: 38,
+				39: 40,
+			},
+			MapInt32Float: map[int32]float32{
+				41:  42.41,
+				432: 44.43,
+			},
+			MapInt32Double: map[int32]float64{
+				45: 46.45,
+				47: 48.47,
+			},
+			MapBoolBool: map[bool]bool{
+				true:  false,
+				false: false,
+			},
+			MapStringString: map[string]string{
+				"Henrik": "David",
+				"Simon":  "Robin",
+			},
+			MapInt32Bytes: map[int32][]byte{
+				49: []byte("Astrid"),
+				50: []byte("Ebba"),
+			},
+			MapInt32Enum: map[int32]types.MapEnum{
+				51: types.MapEnum_MAP_ENUM_BAR,
+				52: types.MapEnum_MAP_ENUM_BAZ,
+			},
+			MapInt32ForeignMessage: map[int32]*types.ForeignMessage{
+				53: {C: 54},
+				55: {C: 56},
+			},
+			MapInt32ImportedMessage: map[int32]*multi.Multi1{
+				57: {
+					Multi2: &multi.Multi2{
+						RequiredValue: 58,
+						Color:         multi.Multi2_RED,
+					},
+					Color:   multi.Multi2_GREEN,
+					HatType: multi.Multi3_FEZ,
+				},
+				59: {
+					Color:   multi.Multi2_BLUE,
+					HatType: multi.Multi3_FEDORA,
+				},
+			},
+		}
+
+		go func() {
+			defer recoverer.Recover() // recovers any panics and fails tests
+			defer qunit.Start()
+
+			resp, err := c.EchoMaps(context.Background(), req)
+			if err != nil {
+				st := status.FromError(err)
+				qunit.Ok(false, "Unexpected error:"+st.Error())
+				return
+			}
+			if diff := deep.Equal(req, resp); diff != nil {
+				var s string
+				for _, v := range diff {
+					s += "\n" + v
+				}
+				qunit.Ok(false, s)
+				return
+			}
+
+			qunit.Ok(true, "Request and Response matched")
+		}()
+
+		return nil
+	})
+
+	qunit.AsyncTest("Unary server call (forcing websocket transport)", func() interface{} {
+		go func() {
+			defer recoverer.Recover() // recovers any panics and fails tests
+			defer qunit.Start()
+
+			c := test.NewTestServiceClient(uri+serverAddr, grpcweb.WithDefaultCallOptions(grpcweb.ForceWebsocketTransport()))
+			w := wrappers.ClientWrapper{C: c}
+			getStatus := func(err error) (codes.Code, string) {
+				st := status.FromError(err)
+				return st.Code, st.Message
+			}
+
+			err := shared.TestPing(w, getStatus)
+			if err != nil {
+				qunit.Ok(false, err.Error())
+				return
+			}
+
+			qunit.Ok(true, "Request succeeded")
+		}()
+
+		return nil
+	})
+
+	qunit.AsyncTest("Server Streaming call (forcing websocket transport)", func() interface{} {
+		go func() {
+			defer recoverer.Recover() // recovers any panics and fails tests
+			defer qunit.Start()
+
+			c := test.NewTestServiceClient(uri+serverAddr, grpcweb.WithDefaultCallOptions(grpcweb.ForceWebsocketTransport()))
+			w := wrappers.ClientWrapper{C: c}
+			getStatus := func(err error) (codes.Code, string) {
+				st := status.FromError(err)
+				return st.Code, st.Message
+			}
 
 			err := shared.TestPingList(w, getStatus)
 			if err != nil {

--- a/test/shared/ping.go
+++ b/test/shared/ping.go
@@ -125,7 +125,7 @@ func TestPing(client TestClient, getStatus func(error) (codes.Code, string)) err
 		ResponseCount: 1,
 	})
 	if err != nil {
-		return errors.WithMessage(err, "send nethier header or trailer")
+		return errors.WithMessage(err, "send neither header or trailer")
 	}
 
 	req := &Request{


### PR DESCRIPTION
As discussed, PR to enable WebSocket usage globally on Client creation via `DialOption`.

Example usage for a service called `P4WNP1`:

```
import pb "../proto/gopherjs" //refers to code generated by protoc-gen-gopherjs without further modifications

... snip ...

func main() {
    ...snip...
    cl := pb.NewP4WNP1Client(addr, grpcweb.ForceWebsocket) //client creation, forcing WebSocket usage
    ...snip...
}
```
